### PR TITLE
fix: remove unexpected drop migration

### DIFF
--- a/hasura/migrations/1599163895451_drop_table_public_offer/up.sql
+++ b/hasura/migrations/1599163895451_drop_table_public_offer/up.sql
@@ -1,1 +1,0 @@
-DROP TABLE "public"."offer";


### PR DESCRIPTION
# Remove unexpected drop migration
Due to bug in production is necessary to remove unexpected drop migration folder in hasura migrations.
﻿
