### PR TITLE
fix/hide sidebar item acorrding to role

### DIFF
--- a/webapp/src/components/Carousel/Carousel.js
+++ b/webapp/src/components/Carousel/Carousel.js
@@ -1,31 +1,42 @@
 import React, { useState } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
 import Box from '@material-ui/core/Box'
 import Button from '@material-ui/core/Button'
 import PropTypes from 'prop-types'
 import Carousel, { slidesToShowPlugin } from '@brainhubeu/react-carousel'
 import '@brainhubeu/react-carousel/lib/style.css'
 
+const useStyles = makeStyles({
+  carousel: {
+    maxWidth: '100%'
+  },
+  img: {
+    maxWidth: '100%'
+  }
+})
+
 const CarouselComponent = ({ images }) => {
+  const classes = useStyles()
   const [actualImageIndex, setActualImageIndex] = useState(0)
 
   return (
     <Box justifyContent="center" borderRadius="8px" boxShadow={2}>
       <Carousel
         value={actualImageIndex}
+        className={classes.carousel}
         onChange={(val) => setActualImageIndex(val)}
         plugins={[
-          'infinite',
           'arrows',
           {
             resolve: slidesToShowPlugin,
             options: {
-              numberOfSlides: 2
+              numberOfSlides: 1
             }
           }
         ]}
       >
         {images.map((url, key) => (
-          <img src={url} key={key} alt={`${key}`} />
+          <img className={classes.img} src={url} key={key} alt={`${key}`} />
         ))}
       </Carousel>
       <Box display="flex" justifyContent="center" alignContent="center">

--- a/webapp/src/containers/SideBar.js
+++ b/webapp/src/containers/SideBar.js
@@ -81,14 +81,16 @@ const SideBar = ({ user, onLogout }) => {
               </Typography>
             </Link>
           </Box>
-          <Box className={classes.optionLink}>
-            <MenuBookIcon className={classes.iconOption} />
-            <Link to="/offers-management">
-              <Typography variant="body1" className={classes.labelOption}>
-                Offers Management
-              </Typography>
-            </Link>
-          </Box>
+          {user.role === 'sponsor' && (
+            <Box className={classes.optionLink}>
+              <MenuBookIcon className={classes.iconOption} />
+              <Link to="/offers-management">
+                <Typography variant="body1" className={classes.labelOption}>
+                  Offers Management
+                </Typography>
+              </Link>
+            </Box>
+          )}
           <Box className={classes.optionLink} onClick={onLogout}>
             <LogoutIcon className={classes.iconOption} />
             <Typography variant="body1" className={classes.labelOption}>


### PR DESCRIPTION
# Hide sidebar item and show it only for sponsor role
- There was a bug in which donors or lifebanks were able to see 'Offer Management' sidebar icon.
Now it's showed only to sponsors
- Fix carousel styles issues

# Linked issues
#238 #239
