### PR TITLE
Feat/additional offer fields

### DIFF
--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -143,16 +143,17 @@
       check: {}
       columns:
       - active
-      - limited
-      - online_only
-      - id
-      - quantity
-      - sponsor_id
+      - cost_in_tokens
       - description
       - end_date
+      - id
       - images
+      - limited
       - offer_name
       - offer_type
+      - online_only
+      - quantity
+      - sponsor_id
       - start_date
       backend_only: false
   select_permissions:
@@ -176,34 +177,36 @@
     permission:
       columns:
       - active
-      - limited
-      - online_only
-      - id
-      - quantity
-      - sponsor_id
+      - cost_in_tokens
       - description
       - end_date
+      - id
       - images
+      - limited
       - offer_name
       - offer_type
+      - online_only
+      - quantity
+      - sponsor_id
       - start_date
       filter: {}
   update_permissions:
   - role: sponsor
     permission:
       columns:
+      - active
+      - cost_in_tokens
+      - description
+      - end_date
+      - id
+      - images
       - limited
+      - offer_name
+      - offer_type
       - online_only
       - quantity
-      - offer_type
-      - description
-      - start_date
-      - end_date
-      - images
       - sponsor_id
-      - id
-      - offer_name
-      - active
+      - start_date
       filter: {}
       check: null
   delete_permissions:

--- a/hasura/migrations/1600362595610_alter_table_public_offer_add_column_const_in_tokens/down.sql
+++ b/hasura/migrations/1600362595610_alter_table_public_offer_add_column_const_in_tokens/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."offer" DROP COLUMN "const_in_tokens";

--- a/hasura/migrations/1600362595610_alter_table_public_offer_add_column_const_in_tokens/up.sql
+++ b/hasura/migrations/1600362595610_alter_table_public_offer_add_column_const_in_tokens/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."offer" ADD COLUMN "const_in_tokens" integer NOT NULL DEFAULT 1;

--- a/hasura/migrations/1600362624704_alter_table_public_offer_alter_column_const_in_tokens/down.sql
+++ b/hasura/migrations/1600362624704_alter_table_public_offer_alter_column_const_in_tokens/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ONLY "public"."offer" ALTER COLUMN "const_in_tokens" SET DEFAULT 1;

--- a/hasura/migrations/1600362624704_alter_table_public_offer_alter_column_const_in_tokens/up.sql
+++ b/hasura/migrations/1600362624704_alter_table_public_offer_alter_column_const_in_tokens/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."offer" ALTER COLUMN "const_in_tokens" DROP DEFAULT;

--- a/hasura/migrations/1600362903320_alter_table_public_offer_alter_column_const_in_tokens/down.sql
+++ b/hasura/migrations/1600362903320_alter_table_public_offer_alter_column_const_in_tokens/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."offer" rename column "cost_in_tokens" to "const_in_tokens";

--- a/hasura/migrations/1600362903320_alter_table_public_offer_alter_column_const_in_tokens/up.sql
+++ b/hasura/migrations/1600362903320_alter_table_public_offer_alter_column_const_in_tokens/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."offer" rename column "const_in_tokens" to "cost_in_tokens";

--- a/webapp/src/gql/offer.gql.js
+++ b/webapp/src/gql/offer.gql.js
@@ -13,6 +13,7 @@ export const CREATE_OFFER_MUTATION = gql`
     $sponsor_id: Int!
     $active: Boolean!
     $offer_name: String!
+    $cost_in_tokens: Int!
   ) {
     insert_offer_one(
       object: {
@@ -27,6 +28,7 @@ export const CREATE_OFFER_MUTATION = gql`
         sponsor_id: $sponsor_id
         active: $active
         offer_name: $offer_name
+        cost_in_tokens: $cost_in_tokens
       }
     ) {
       id
@@ -66,6 +68,7 @@ export const UPDATE_OFFER_MUTATION = gql`
     $images: String
     $active: Boolean
     $offer_name: String
+    $cost_in_tokens: Int!
     $id: Int!
   ) {
     update_offer(
@@ -80,6 +83,7 @@ export const UPDATE_OFFER_MUTATION = gql`
         images: $images
         active: $active
         offer_name: $offer_name
+        cost_in_tokens: $cost_in_tokens
       }
       where: { id: { _eq: $id } }
     ) {
@@ -104,6 +108,7 @@ export const GET_SPONSOR_OFFERS_QUERY = gql`
       start_date
       end_date
       offer_name
+      cost_in_tokens
       active
     }
   }

--- a/webapp/src/routes/OffersManagement/GenericOfferFormComponent.js
+++ b/webapp/src/routes/OffersManagement/GenericOfferFormComponent.js
@@ -193,7 +193,8 @@ const GenericOfferFormComponent = ({
       end_date,
       offer_name,
       id,
-      active
+      active,
+      cost_in_tokens
     } = offer
 
     const images = JSON.stringify(offer.images)
@@ -208,6 +209,7 @@ const GenericOfferFormComponent = ({
           quantity: quantity || undefined,
           start_date: start_date || undefined,
           end_date: end_date || undefined,
+          cost_in_tokens,
           images,
           sponsor_id,
           active: true,
@@ -224,6 +226,7 @@ const GenericOfferFormComponent = ({
           quantity,
           start_date,
           end_date,
+          cost_in_tokens,
           images,
           offer_name,
           id,
@@ -384,6 +387,22 @@ const GenericOfferFormComponent = ({
             )}
           </FormControl>
           <TextField
+            id="cost-in-tokens"
+            label="Cost in tokens (number)"
+            variant="outlined"
+            type="number"
+            placeholder="Type here"
+            value={offer.cost_in_tokens || undefined}
+            fullWidth
+            InputLabelProps={{
+              shrink: true
+            }}
+            onChange={(event) =>
+              setOffer({ ...offer, cost_in_tokens: event.target.value })
+            }
+            className={classes.textField}
+          />
+          <TextField
             id="image-url"
             label="Image url"
             variant="outlined"
@@ -433,6 +452,7 @@ const GenericOfferFormComponent = ({
                 updateOfferLoading ||
                 !offer.description ||
                 !offer.offer_type ||
+                !offer.cost_in_tokens ||
                 offer.images.length < 1
               }
               onClick={handleSubmit}

--- a/webapp/src/routes/OffersManagement/OfferDetails.js
+++ b/webapp/src/routes/OffersManagement/OfferDetails.js
@@ -20,6 +20,7 @@ import BallotIcon from '@material-ui/icons/Ballot'
 import LocationOffIcon from '@material-ui/icons/LocationOff'
 import LocationOnIcon from '@material-ui/icons/LocationOn'
 import ReceiptIcon from '@material-ui/icons/Receipt'
+import StyleIcon from '@material-ui/icons/Style'
 import * as m from 'moment-timezone'
 import moment from 'moment'
 
@@ -131,6 +132,14 @@ const OfferDetails = ({ offer, open, setOpen }) => {
               </ListItemIcon>
               <ListItemText>
                 <strong>Offer type: </strong> {offer.offer_type}
+              </ListItemText>
+            </ListItem>
+            <ListItem>
+              <ListItemIcon>
+                <StyleIcon color="secondary" />
+              </ListItemIcon>
+              <ListItemText>
+                <strong>Cost in tokens: </strong> {offer.cost_in_tokens}
               </ListItemText>
             </ListItem>
             <ListItem>


### PR DESCRIPTION
## Add `cost_in_tokens ` field to offer
This allows sponsors to indicate how much is the token cost of a specific offer.
# How this should be tested?
- Execute `make install` command (in case you don't have the dependencies).
- Execute `make run` command.
- Go to `localhost:3000` and go to Sponsor offer management and add a new offer.
