### PR TITLE
style(frontend): Fix video style (height, width and position) on about

### DIFF
--- a/webapp/src/components/VideoSection/VideoSection.js
+++ b/webapp/src/components/VideoSection/VideoSection.js
@@ -5,7 +5,7 @@ const Video = ({ ...pros }) => (
   <iframe
     title={'unique' + Math.random()}
     width="100%"
-    height="100%"
+    height="400px"
     frameBorder="0"
     allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
     allowFullScreen

--- a/webapp/src/routes/About/About.js
+++ b/webapp/src/routes/About/About.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { makeStyles } from '@material-ui/styles'
 import Box from '@material-ui/core/Box'
 import Typography from '@material-ui/core/Typography'
+import CardMedia from '@material-ui/core/CardMedia';
 
 import VideoSection from '../../components/VideoSection'
 
@@ -27,7 +28,11 @@ const useStyles = makeStyles((theme) => ({
     }
   },
   video: {
-    marginBottom: theme.spacing(2)
+    margin: "auto",
+    maxWidth: "800px",
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+    borderRadius: "1rem"
   }
 }))
 


### PR DESCRIPTION
#304 

### What does this PR do?
I use "px" value unit instead of percentage. That's because iframe element accept only pixel values for height and width. Then I correct the width of the VideoSection component so it does not expand fully. I think it's better because of the aspect ratio of the video file. After that I center align. Also added some border-radius. I hope you like it

### How this should be tested?

go to http://localhost:3000/about