### PR TITLE
fix: delete cache assets config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -24,10 +24,6 @@ http {
     gzip_types text/plain text/css text/html application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
     gunzip on; # Uncompress on the fly
 
-    location ~* \.(jpg|jpeg|png|gif|ico)$ {
-      expires 365d;
-    }
-
     listen 443 ssl;
     server_name lifebank.io;
 

--- a/webapp/nginx.conf
+++ b/webapp/nginx.conf
@@ -6,10 +6,6 @@ server {
     expires 365d;
   }
 
-  location ~* \.(jpg|jpeg|png|gif|ico)$ {
-    expires 365d;
-  }
-
   location / {
     root /usr/share/nginx/html;
     index index.html index.htm;

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -72,7 +72,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  <link rel="preconnect" href="https://fonts.gstatic.com">
   <script defer src="https://www.google.com/recaptcha/api.js" async></script>
 </body>
 


### PR DESCRIPTION
# Delete cache assets config
Due to 404 missing error when trying to get assets like png, jpg, ico; better to remove the cache config to this specific assets.
# How this should be tested?
- Generate production build locally and then serve that on one specific port
- Go home and see assets get served
## Linked issues
closes #407 