### PR TITLE
fix: add photos validation in account api

### DIFF
--- a/hapi/src/api/account.api.js
+++ b/hapi/src/api/account.api.js
@@ -238,6 +238,7 @@ const getValidSponsors = async () => {
       sponsorsAccounts[index].info.address.length > 0 &&
       sponsorsAccounts[index].info.email.length > 0 &&
       sponsorsAccounts[index].info.location !== 'null' &&
+      JSON.parse(sponsorsAccounts[index].info.photos).length > 0 &&
       JSON.parse(sponsorsAccounts[index].info.telephones).length > 0
     )
       validSponsors.push({
@@ -282,6 +283,7 @@ const getValidLifebanks = async () => {
       lifebankAccounts[index].info.email.length > 0 &&
       lifebankAccounts[index].info.about.length > 0 &&
       lifebankAccounts[index].info.geolocation !== 'null' &&
+      JSON.parse(lifebankAccounts[index].info.photos).length > 0 &&
       JSON.parse(lifebankAccounts[index].info.telephones).length > 0
     )
       validLifebanks.push({
@@ -365,7 +367,7 @@ const grantConsent = async account => {
   return consentTransaction
 }
 
-const formatSchedule = (schedule) => {
+const formatSchedule = schedule => {
   let scheduleFormat = ''
 
   let hours
@@ -375,7 +377,7 @@ const formatSchedule = (schedule) => {
   return scheduleFormat.replace(',', ' ')
 }
 
-const formatLifebankData = (lifebankData) => {
+const formatLifebankData = lifebankData => {
   lifebankData.schedule = formatSchedule(JSON.parse(lifebankData.schedule))
   lifebankData.coordinates = JSON.parse(lifebankData.coordinates)
   if (lifebankData.immunity_test) lifebankData.immunity_test = 'Yes'

--- a/hapi/src/api/account.api.js
+++ b/hapi/src/api/account.api.js
@@ -238,7 +238,6 @@ const getValidSponsors = async () => {
       sponsorsAccounts[index].info.address.length > 0 &&
       sponsorsAccounts[index].info.email.length > 0 &&
       sponsorsAccounts[index].info.location !== 'null' &&
-      JSON.parse(sponsorsAccounts[index].info.photos).length > 0 &&
       JSON.parse(sponsorsAccounts[index].info.telephones).length > 0
     )
       validSponsors.push({
@@ -283,7 +282,6 @@ const getValidLifebanks = async () => {
       lifebankAccounts[index].info.email.length > 0 &&
       lifebankAccounts[index].info.about.length > 0 &&
       lifebankAccounts[index].info.geolocation !== 'null' &&
-      JSON.parse(lifebankAccounts[index].info.photos).length > 0 &&
       JSON.parse(lifebankAccounts[index].info.telephones).length > 0
     )
       validLifebanks.push({

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.2 as build-stage
+FROM node:12.16.2-slim as build-stage
 
 ENV WORK_DIR /app
 ENV PATH $WORK_DIR/node_modules/.bin:$PATH

--- a/webapp/src/components/LocalBusinessStructuredData/LocalBusinessStructuredData.js
+++ b/webapp/src/components/LocalBusinessStructuredData/LocalBusinessStructuredData.js
@@ -40,7 +40,10 @@ const LocalBusinessStructuredData = ({
               ? 'https://raw.githubusercontent.com/eoscostarica/lifebank/6ec27b8c7832ba6ccb4adebfe1ba8d1d94eb0544/docs/logos/2-OverWhite-lifebank-logo-v1-may25-2020-01.svg'
               : logo,
           email: email,
-          image: photos[0],
+          image:
+            photos.length === 0
+              ? 'https://dummyimage.com/640x360/fff/aaa'
+              : photos[0],
           location: location,
           telephone: JSON.parse(telephone)[0]
         }}

--- a/webapp/src/components/MedicalClinicStructuredData/MedicalClinicStructuredData.js
+++ b/webapp/src/components/MedicalClinicStructuredData/MedicalClinicStructuredData.js
@@ -27,7 +27,10 @@ const MedicalClinicStructuredData = ({
             ? 'https://raw.githubusercontent.com/eoscostarica/lifebank/6ec27b8c7832ba6ccb4adebfe1ba8d1d94eb0544/docs/logos/2-OverWhite-lifebank-logo-v1-may25-2020-01.svg'
             : logo,
         email: email,
-        image: photos[0],
+        image:
+          photos.length === 0
+            ? 'https://dummyimage.com/640x360/fff/aaa'
+            : photos[0],
         description: description,
         location: location,
         telephone: JSON.parse(telephone)[0]


### PR DESCRIPTION
# Add photos validation in account.api
This PR provides a fix for missing photos field validation when getting valid sponsors and valid lifebanks
## What does this PR do?
- Provide a fix for missing photos validation in the backend
## Linked issues
closes #436
## Notes
In order to test this, you can go to https://search.google.com/test/rich-results and test the functionality when this PR is deployed