### PR TITLE
Lifebanks and Sponsors are not showing the about text on their sections.

### DIFF
--- a/webapp/src/routes/InfoPage/InfoPageDesktop.js
+++ b/webapp/src/routes/InfoPage/InfoPageDesktop.js
@@ -370,7 +370,7 @@ const InfoPage = () => {
                 </Typography>
                 <Typography className={classes.text} variant="body1">
                   {' '}
-                  {profile.about}
+                  {profile.description}
                 </Typography>
               </Box>
               <Divider className={classes.divider} />


### PR DESCRIPTION
## Lifebanks and Sponsors are not showing the about text on their sections.

closes #443 

### What does this PR do?
- Load about in version desktop

### How should this be tested?

- Run make run
- Go to localhost:3000
- Go to info page version desktop. 