### PR TITLE
fix(backend): dont update token until transaction is approved

### DIFF
--- a/hapi/src/api/account.api.js
+++ b/hapi/src/api/account.api.js
@@ -484,15 +484,6 @@ const transfer = async (from, details) => {
 
   let transaction
 
-  await userApi.setToken(
-    { account: { _eq: user.account } },
-    user.token - details.quantity
-  )
-  await userApi.setToken(
-    { account: { _eq: details.to } },
-    userTo.token + details.quantity
-  )
-
   switch (user.role) {
     case 'donor' || 'sponsor':
       transaction = await lifebankcoinUtils.transfer(from, password, details)
@@ -502,6 +493,17 @@ const transfer = async (from, details) => {
       break
     default:
       break
+  }
+
+  if (transaction.processed) {
+    await userApi.setToken(
+      { account: { _eq: user.account } },
+      user.token - details.quantity
+    )
+    await userApi.setToken(
+      { account: { _eq: details.to } },
+      userTo.token + details.quantity
+    )
   }
 
   const newBalance = await lifebankcoinUtils.getbalance(details.to)


### PR DESCRIPTION
Resolves #545  

### What does this PR do?
Don't update the the token column amount until a transaction is verified.

### How should this be tested?
- Make run
- Go to Lifebank token transfer
- Transfer tokens with an unconsent Lifebank user