### PR TITLE
fix(backend): set email verified register-lifebank is executed

### DIFF
--- a/hapi/src/api/account.api.js
+++ b/hapi/src/api/account.api.js
@@ -107,7 +107,8 @@ const createLifebank = async ({
     email,
     secret,
     name,
-    verification_code
+    verification_code,
+    email_verified: true
   })
 
   await vaultApi.insert({


### PR DESCRIPTION
Resolves #570 

### What does this PR do?
Set email-verified flag to true when a new lifebank is added to user table

### How should this be tested?
- Make run
- Register as Lifebank
- When register-lifebank is executed, check lifebank email-verified flag is set to true when is added to user table