### PR TITLE
fix(backend): Update start total lifebank tokens

### DIFF
--- a/hapi/src/api/account.api.js
+++ b/hapi/src/api/account.api.js
@@ -107,7 +107,8 @@ const createLifebank = async ({
     email,
     secret,
     name,
-    verification_code
+    verification_code,
+    token: 1000000
   })
 
   await vaultApi.insert({


### PR DESCRIPTION
Resolves #540 

### What does this PR do?
Set start total Lifebank tokens to 1000000 when a new Lifebank is added to user table

### How should this be tested?
- Make run
- Register as Lifebank
- When register-lifebank is executed, check lifebank start total Lifebank tokens is set to 1000000 when is added to user table