### PR TITLE
Fix/social signup

### DIFF
--- a/hapi/src/api/account.api.js
+++ b/hapi/src/api/account.api.js
@@ -16,6 +16,7 @@ const locationApi = require('./location.api')
 const preRegLifebank = require('./pre-register.api')
 const verificationCodeApi = require('./verification-code.api')
 const mailApi = require('../utils/mail')
+const verifyEmailHandler = require('../routes/verify-email/verify-email.handler')
 const LIFEBANKCODE_CONTRACT = eosConfig.lifebankCodeContractName
 const MAIL_APPROVE_LIFEBANNK = eosConfig.mailApproveLifebank
 
@@ -45,7 +46,7 @@ query MyQuery {
 }
 `
 
-const create = async ({ role, email, emailContent, name, secret }) => {
+const create = async ({ role, email, emailContent, name, secret, signup_method }) => {
   const account = await eosUtils.generateRandomAccountName(role.substring(0, 3))
   const { password, transaction } = await eosUtils.createAccount(account)
   const username = account
@@ -59,7 +60,8 @@ const create = async ({ role, email, emailContent, name, secret }) => {
     email,
     secret,
     name,
-    verification_code
+    verification_code,
+    signup_method
   })
 
   await vaultApi.insert({
@@ -164,6 +166,27 @@ const getProfile = async (account) => {
     role: user.role,
     id: user.id,
     ...data
+  }
+}
+
+const isPasswordChangable = async ({ email }) => {
+  const user = await userApi.getOne({
+    email: { _eq: email }
+  })
+
+  if (user) {
+    switch (user.signup_method) {
+      case 'google': case 'facebook':
+        return {
+          password_changable: false
+        }
+      default:
+        break
+    }
+  }
+
+  return {
+    password_changable: true
   }
 }
 
@@ -533,6 +556,7 @@ module.exports = {
   create,
   createLifebank,
   getProfile,
+  isPasswordChangable,
   login,
   grantConsent,
   revokeConsent,

--- a/hapi/src/api/user.api.js
+++ b/hapi/src/api/user.api.js
@@ -11,6 +11,7 @@ const GET_ONE = `
       email
       name
       token
+      signup_method
     }
   }
 `

--- a/hapi/src/routes/create-account/create-account.validation.js
+++ b/hapi/src/routes/create-account/create-account.validation.js
@@ -7,7 +7,8 @@ module.exports = {
       email: Joi.string().required(),
       emailContent: Joi.object().required(),
       name: Joi.string().required(),
-      secret: Joi.string().required()
+      secret: Joi.string().required(),
+      signup_method: Joi.string().required()
     })
   }).options({ stripUnknown: true })
 }

--- a/hapi/src/routes/index.js
+++ b/hapi/src/routes/index.js
@@ -15,6 +15,7 @@ const preregisterLifebankRoute = require('./pre-register/pre-register-lifebank.r
 const registerLifebankRoute = require('./create-account-lifebank/create-account-lifebank.route')
 const verifyEmailRouteRoute = require('./verify-email/verify-email.route')
 const getValidLifebanksRoute = require('./get-valid-lifebanks/get-valid-lifebanks.route')
+const checkSignupMethod = require('./signup-method/signup-method.route')
 
 module.exports = [
   changePasswordRoute,
@@ -33,5 +34,6 @@ module.exports = [
   preregisterLifebankRoute,
   registerLifebankRoute,
   verifyEmailRouteRoute,
-  getValidLifebanksRoute
+  getValidLifebanksRoute,
+  checkSignupMethod
 ]

--- a/hapi/src/routes/signup-method/signup-method.handler.js
+++ b/hapi/src/routes/signup-method/signup-method.handler.js
@@ -1,0 +1,13 @@
+const Boom = require('@hapi/boom')
+const { BAD_REQUEST } = require('http-status-codes')
+const { accountApi } = require('../../api')
+
+module.exports = async ({ payload: { input } }) => {
+  try {
+    const response = await accountApi.isPasswordChangable(input)
+    return response
+  } catch (error) {
+    console.error(error)
+    return Boom.boomify(error, { statusCode: BAD_REQUEST })
+  }
+}

--- a/hapi/src/routes/signup-method/signup-method.route.js
+++ b/hapi/src/routes/signup-method/signup-method.route.js
@@ -1,0 +1,10 @@
+const signupMethodHandler = require('./signup-method.handler')
+
+module.exports = {
+  method: 'POST',
+  path: '/api/signup-method',
+  handler: signupMethodHandler,
+  options: {
+    auth: false
+  }
+}

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -23,6 +23,7 @@ type Mutation {
     emailContent: jsonb!
     name: String!
     secret: String!
+    signup_method: String!
   ): create_account_output
 }
 
@@ -115,6 +116,13 @@ type Mutation {
   signup (
     profile: jsonb!
   ): signup_output
+}
+
+
+type Mutation {
+  signup_method (
+    email: String!
+  ): signup_method_output
 }
 
 
@@ -240,5 +248,9 @@ type create_account_lifebank_output {
 
 type change_password_output {
   success : Boolean!
+}
+
+type signup_method_output {
+  password_changable : Boolean!
 }
 

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -116,6 +116,13 @@ actions:
   - role: donor
   - role: lifebank
   - role: sponsor
+- name: signup_method
+  definition:
+    kind: synchronous
+    handler: http://hapi:9090/api/signup-method
+    forward_client_headers: true
+  permissions:
+  - role: guest
 - name: transfer
   definition:
     kind: synchronous
@@ -156,4 +163,5 @@ custom_types:
   - name: ValidLifebank
   - name: create_account_lifebank_output
   - name: change_password_output
+  - name: signup_method_output
   scalars: []

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -325,16 +325,17 @@
   - role: guest
     permission:
       columns:
-      - id
-      - role
-      - username
       - account
-      - secret
+      - created_at
       - email
       - email_verified
-      - created_at
-      - updated_at
+      - id
       - name
+      - role
+      - secret
+      - signup_method
+      - updated_at
+      - username
       filter: {}
   - role: lifebank
     permission:

--- a/hasura/migrations/1617031860483_alter_table_public_user_add_column_signup_method/down.sql
+++ b/hasura/migrations/1617031860483_alter_table_public_user_add_column_signup_method/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."user" DROP COLUMN "signup_method";

--- a/hasura/migrations/1617031860483_alter_table_public_user_add_column_signup_method/up.sql
+++ b/hasura/migrations/1617031860483_alter_table_public_user_add_column_signup_method/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."user" ADD COLUMN "signup_method" varchar NOT NULL DEFAULT 'lifebank';

--- a/webapp/src/components/Signup/Signup.js
+++ b/webapp/src/components/Signup/Signup.js
@@ -257,14 +257,15 @@ const Signup = ({ isHome, isModal, isSideBar }) => {
               button: t('emailMessage.verifyButton')
             },
             name,
-            secret: hash
+            secret: hash,
+            signup_method: 'lifebank'
           }
         })
       }
     })
   }
 
-  const handleCreateAccountWithAuth = async (status, email, name, secret) => {
+  const handleCreateAccountWithAuth = async (status, email, name, secret, signupMethod) => {
     if (status) {
       const { data } = await checkEmail({ email: email })
 
@@ -278,8 +279,15 @@ const Signup = ({ isHome, isModal, isSideBar }) => {
               variables: {
                 role,
                 email,
+                emailContent: {
+                  subject: t('emailMessage.subjectVerificationCode'),
+                  title: t('emailMessage.titleVerificationCode'),
+                  message: t('emailMessage.messageVerificationCode'),
+                  button: t('emailMessage.verifyButton')
+                },
                 name,
-                secret: hash
+                secret: hash,
+                signup_method: signupMethod
               }
             })
           }

--- a/webapp/src/components/Signup/socialSingup/SignupWithFacebook.js
+++ b/webapp/src/components/Signup/socialSingup/SignupWithFacebook.js
@@ -41,7 +41,8 @@ const SignupWithFacebook = ({ handlerSubmit }) => {
       true,
       response.profile.email,
       response.profile.name,
-      response.profile.id
+      response.profile.id,
+      'facebook'
     )
   }
 

--- a/webapp/src/components/Signup/socialSingup/SignupWithGoogle.js
+++ b/webapp/src/components/Signup/socialSingup/SignupWithGoogle.js
@@ -42,7 +42,8 @@ const SignupWithGoogle = ({ handlerSubmit }) => {
       true,
       response.profileObj.email,
       response.profileObj.name,
-      response.profileObj.googleId
+      response.profileObj.googleId,
+      'google'
     )
   }
 

--- a/webapp/src/gql/account.gql.js
+++ b/webapp/src/gql/account.gql.js
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag'
 
 export const CREATE_ACCOUNT_MUTATION = gql`
-  mutation($role: String!, $email: String!, $emailContent: jsonb!, $name: String!, $secret: String!) {
-    create_account(role: $role, email: $email, emailContent: $emailContent, name: $name, secret: $secret) {
+  mutation($role: String!, $email: String!, $emailContent: jsonb!, $name: String!, $secret: String!, $signup_method: String!) {
+    create_account(role: $role, email: $email, emailContent: $emailContent, name: $name, secret: $secret, signup_method: $signup_method) {
       account
       token
       transaction_id
@@ -184,6 +184,14 @@ export const VALIDATE_EMAIL = gql`
   query($email: String!) {
     user(where: { email: { _eq: $email } }) {
       email
+    }
+  }
+`
+
+export const GET_ACCOUNT_SIGNUP_METHOD = gql`
+  mutation ($email: String!) {
+    signup_method(email: $email) {
+      password_changable
     }
   }
 `

--- a/webapp/src/language/en.json
+++ b/webapp/src/language/en.json
@@ -346,7 +346,7 @@
       "instructionCredentialsRecovery": "Enter the email associated with your account to be able to recover it",
       "checkYourEmail": "Check your email",
       "recovery": "Recover",
-      "passwordNotChangable": "Please, log in into your Facebook or Google account to change your password"
+      "passwordNotChangable": "Please, log in to your Facebook or Google account to change your password"
     },
     "emailVerification": {
       "emailVerified": "Your email has been verified",

--- a/webapp/src/language/en.json
+++ b/webapp/src/language/en.json
@@ -345,7 +345,8 @@
       "newPassword": "New password",
       "instructionCredentialsRecovery": "Enter the email associated with your account to be able to recover it",
       "checkYourEmail": "Check your email",
-      "recovery": "Recover"
+      "recovery": "Recover",
+      "passwordNotChangable": "Please, log in into your Facebook or Google account to change your password"
     },
     "emailVerification": {
       "emailVerified": "Your email has been verified",

--- a/webapp/src/language/es.json
+++ b/webapp/src/language/es.json
@@ -344,7 +344,8 @@
       "newPassword": "Nueva contraseña",
       "instructionCredentialsRecovery": "Ingrese el correo asociado a su cuenta para poder recuperarla",
       "checkYourEmail": "Revisa tu correo",
-      "recovery": "Recuperar"
+      "recovery": "Recuperar",
+      "passwordNotChangable": "Ingrese a su cuenta de Facebook o Google para cambiar la contraseña."
     },
     "emailVerification": {
       "emailVerified": "Tu correo ha sido verificado",

--- a/webapp/src/language/es.json
+++ b/webapp/src/language/es.json
@@ -345,7 +345,7 @@
       "instructionCredentialsRecovery": "Ingrese el correo asociado a su cuenta para poder recuperarla",
       "checkYourEmail": "Revisa tu correo",
       "recovery": "Recuperar",
-      "passwordNotChangable": "Ingrese a su cuenta de Facebook o Google para cambiar la contraseña."
+      "passwordNotChangable": "Ingrese a su cuenta de Facebook o Google para cambiar la contraseña"
     },
     "emailVerification": {
       "emailVerified": "Tu correo ha sido verificado",


### PR DESCRIPTION
Resolves #607 

### What does this PR do?
Disable the change password or recovery password if the user sign up by Google or Facebook

### How should this be tested?
- Make run
- Go to Credential Recovery
- Try to change password from an account that was registered by Google or Facebook medium (disabled)
- Try to change password from an account that was registered by Lifebank platform (enabled)
