### PR TITLE
fix(typo): credentials error message

### DIFF
--- a/webapp/src/language/en.json
+++ b/webapp/src/language/en.json
@@ -337,7 +337,7 @@
     },
     "credentialsRecovery": {
       "credentialsRecovery": "Credentials Recovery",
-      "emailError": "The email entered is not associated with any accoun",
+      "emailError": "The email entered is not associated with any account",
       "changePasswordInstructions": "To change your password, enter the email associated with your account, the current password and the new one",
       "changePassword": "Change Password",
       "currentPassword": "Current password",


### PR DESCRIPTION
Resolves #610 

### What does this PR do?
Credentials       "emailError": "The email entered is not associated with any account",

### How should this be tested?
- Make run
- Try to recover your credentials with a random email

