### PR TITLE
fix(frontend): Load info in filter component

### DIFF
--- a/webapp/src/routes/OffersManagement/OffersManagement.js
+++ b/webapp/src/routes/OffersManagement/OffersManagement.js
@@ -109,14 +109,7 @@ const OffersManagement = () => {
   const [openGenericFormAddVariant, setOpenGenericFormAddVariant] = useState(
     false
   )
-  const columns = [
-    t('offersManagement.offerName'),
-    t('offersManagement.startDate'),
-    t('offersManagement.endDate'),
-    t('offersManagement.status'),
-    t('offersManagement.actions'),
-    t('offersManagement.details')
-  ]
+
   const [openGenericFormEditVariant, setOpenGenericFormEditVariant] = useState(
     false
   )
@@ -309,6 +302,7 @@ const OffersManagement = () => {
                   offer.active
                     ? t('offersManagement.active')
                     : t('offersManagement.inactive'),
+
                   Actions(offer.active, offer.id),
                   <IconButton
                     key={key}
@@ -318,15 +312,52 @@ const OffersManagement = () => {
                     <MoreHorizIcon />
                   </IconButton>
                 ])}
-                columns={columns}
+                columns={[
+                  {
+                    name: t('offersManagement.offerName'),
+                    options: {
+                      filter: true,
+                    }
+                  },
+                  {
+                    name: t('offersManagement.startDate'),
+                    options: {
+                      filter: true,
+                    }
+                  },
+                  {
+                    name: t('offersManagement.endDate'),
+                    options: {
+                      filter: true,
+                    }
+                  },
+                  {
+                    name: t('offersManagement.status'),
+                    options: {
+                      filter: true,
+                    }
+                  },
+                  {
+                    name: t('offersManagement.actions'),
+                    options: {
+                      filter: false,
+                    }
+                  },
+                  {
+                    name: t('offersManagement.details'),
+                    options: {
+                      filter: false,
+                    }
+                  }
+                ]}
                 options={{
-                  filter: true,
                   print: false,
                   selectableRowsHideCheckboxes: true,
                   selectableRowsHeader: false,
                   download: false,
                 }}
               />
+
             </Box>
           }
           {offers.length === 0 &&

--- a/webapp/src/routes/OffersManagement/OffersManagement.js
+++ b/webapp/src/routes/OffersManagement/OffersManagement.js
@@ -293,15 +293,15 @@ const OffersManagement = () => {
                 title={t('offersManagement.tableTitle')}
                 data={offers.map((offer, key) => [
                   offer.offer_name,
+                  offer.active
+                    ? t('offersManagement.active')
+                    : t('offersManagement.inactive'),
                   offer.start_date
                     ? m(offer.start_date).tz(timezone).format('DD-MM-YYYY')
                     : t('offersManagement.noProvidedDate'),
                   offer.end_date
                     ? m(offer.end_date).tz(timezone).format('DD-MM-YYYY')
                     : t('offersManagement.noProvidedDate'),
-                  offer.active
-                    ? t('offersManagement.active')
-                    : t('offersManagement.inactive'),
 
                   Actions(offer.active, offer.id),
                   <IconButton
@@ -320,6 +320,12 @@ const OffersManagement = () => {
                     }
                   },
                   {
+                    name: t('offersManagement.status'),
+                    options: {
+                      filter: true,
+                    }
+                  },
+                  {
                     name: t('offersManagement.startDate'),
                     options: {
                       filter: true,
@@ -327,12 +333,6 @@ const OffersManagement = () => {
                   },
                   {
                     name: t('offersManagement.endDate'),
-                    options: {
-                      filter: true,
-                    }
-                  },
-                  {
-                    name: t('offersManagement.status'),
                     options: {
                       filter: true,
                     }


### PR DESCRIPTION
Resolves #483 

### What does this PR do?
Remove unnecessary filters from the offer table

### How should this be tested?
- Make run
- Login as a Sponsor
- Go to Offers Management
- Select filter icon 


![image](https://user-images.githubusercontent.com/31549144/113921389-2e77d200-97a3-11eb-9b8f-5faf59ab4283.png)



