### PR TITLE
fix(frontend) fix Sponsor and Lifebank profile

### DIFF
--- a/webapp/src/routes/Profile/ProfilePageLifebank.js
+++ b/webapp/src/routes/Profile/ProfilePageLifebank.js
@@ -86,7 +86,7 @@ const useStyles = makeStyles((theme) => ({
       textTransform: 'capitalize'
     }
   },
-  rowBoxEmail: {
+  rowBoxInfo: {
     display: 'flex',
     width: '100%',
     justifyContent: 'space-between',
@@ -411,7 +411,7 @@ const ProfilePageLifebank = ({ profile }) => {
       {profile.email &&
         <>
           <Divider className={classes.divider} />
-          <Box className={classes.rowBoxEmail}>
+          <Box className={classes.rowBoxInfo}>
             <Typography className={classes.rowTitle} variant="subtitle1">{t('common.email')}</Typography>
             <Typography variant="body1">{profile.email}</Typography>
           </Box>
@@ -468,7 +468,7 @@ const ProfilePageLifebank = ({ profile }) => {
       {profile.about &&
         <>
           <Divider className={classes.divider} />
-          <Box className={classes.rowBoxLeft}>
+          <Box className={classes.rowBoxInfo}>
             <Typography className={classes.rowTitle} variant="subtitle1">{t('signup.about')}</Typography>
             <Typography >{profile.about}</Typography>
           </Box>
@@ -477,7 +477,7 @@ const ProfilePageLifebank = ({ profile }) => {
       {profile.requirement &&
         <>
           <Divider className={classes.divider} />
-          <Box className={classes.rowBoxLeft}>
+          <Box className={classes.rowBoxInfo}>
             <Typography className={classes.rowTitle} variant="subtitle1">{t('signup.requirement')}</Typography>
             <Typography >{profile.requirement.replaceAll("\n", ", ")}</Typography>
           </Box>
@@ -486,7 +486,7 @@ const ProfilePageLifebank = ({ profile }) => {
       {profile.schedule &&
         <>
           <Divider className={classes.divider} />
-          <Box className={classes.rowBoxLeft}>
+          <Box className={classes.rowBoxInfo}>
             <Typography className={classes.rowTitle} variant="subtitle1">{t('common.schedule')}</Typography>
             <ViewSchedule schedule={profile.schedule} />
           </Box>
@@ -495,7 +495,7 @@ const ProfilePageLifebank = ({ profile }) => {
       {profile.categories &&
         <>
           <Divider className={classes.divider} />
-          <Box className={classes.rowBoxLeft}>
+          <Box className={classes.rowBoxInfo}>
             <Typography className={classes.rowTitle} variant="subtitle1">{t('common.categories')}</Typography>
             <ViewCategories categories={profile.categories} />
           </Box>

--- a/webapp/src/routes/Profile/ProfilePageLifebank.js
+++ b/webapp/src/routes/Profile/ProfilePageLifebank.js
@@ -86,6 +86,16 @@ const useStyles = makeStyles((theme) => ({
       textTransform: 'capitalize'
     }
   },
+  rowBoxEmail: {
+    display: 'flex',
+    width: '100%',
+    justifyContent: 'space-between',
+    padding: theme.spacing(2, 2),
+    alignItems: 'center',
+    '& p': {
+      color: theme.palette.secondary.onSecondaryMediumEmphasizedText
+    }
+  },
   rowTitle: {
     fontWeight: 'bold',
     marginRight: '10px'
@@ -280,7 +290,7 @@ const ProfilePageLifebank = ({ profile }) => {
     if (!profile.about)
       pendingFieldsObject = { ...pendingFieldsObject, about: false }
 
-      if (!profile.requirement)
+    if (!profile.requirement)
       pendingFieldsObject = { ...pendingFieldsObject, requirement: false }
 
     if (!profile.blood_urgency_level)
@@ -401,7 +411,7 @@ const ProfilePageLifebank = ({ profile }) => {
       {profile.email &&
         <>
           <Divider className={classes.divider} />
-          <Box className={classes.rowBox}>
+          <Box className={classes.rowBoxEmail}>
             <Typography className={classes.rowTitle} variant="subtitle1">{t('common.email')}</Typography>
             <Typography variant="body1">{profile.email}</Typography>
           </Box>

--- a/webapp/src/routes/Profile/ProfilePageSponsor.js
+++ b/webapp/src/routes/Profile/ProfilePageSponsor.js
@@ -90,6 +90,17 @@ const useStyles = makeStyles((theme) => ({
       textTransform: 'capitalize'
     }
   },
+  rowBoxInfo: {
+    display: 'flex',
+    width: '100%',
+    justifyContent: 'space-between',
+    padding: theme.spacing(2, 2),
+    alignItems: 'center',
+    '& p': {
+      color: theme.palette.secondary.onSecondaryMediumEmphasizedText,
+      textTransform: 'initial'
+    }
+  },
   rowTitle: {
     fontWeight: 'bold',
     marginRight: '10px'
@@ -534,7 +545,7 @@ const ProfilePageSponsor = ({ profile }) => {
       {profile.address &&
         <>
           <Divider className={classes.divider} />
-          <Box className={classes.rowBox}>
+          <Box className={classes.rowBoxInfo}>
             <Typography className={classes.rowTitle} variant="subtitle1">{t('signup.address')}</Typography>
             <Typography variant="body1">{profile.address}</Typography>
           </Box>
@@ -594,7 +605,7 @@ const ProfilePageSponsor = ({ profile }) => {
       {profile.schedule &&
         <>
           <Divider className={classes.divider} />
-          <Box className={classes.rowBoxLeft}>
+          <Box className={classes.rowBox}>
             <Typography className={classes.rowTitle} variant="subtitle1">{t('common.schedule')}</Typography>
             <ViewSchedule schedule={profile.schedule} />
           </Box>
@@ -603,7 +614,7 @@ const ProfilePageSponsor = ({ profile }) => {
       {profile.about &&
         <>
           <Divider className={classes.divider} />
-          <Box className={classes.rowBoxLeft}>
+          <Box className={classes.rowBoxInfo}>
             <Typography className={classes.rowTitle} variant="subtitle1">{t('signup.about')}</Typography>
             <Typography >{profile.about}</Typography>
           </Box>
@@ -612,7 +623,7 @@ const ProfilePageSponsor = ({ profile }) => {
       {profile.covid_impact &&
         <>
           <Divider className={classes.divider} />
-          <Box className={classes.rowBoxLeft}>
+          <Box className={classes.rowBoxInfo}>
             <Typography className={classes.rowTitle} variant="subtitle1">{t('editProfile.covidImpact')}</Typography>
             <Typography >{profile.covid_impact}</Typography>
           </Box>
@@ -621,7 +632,7 @@ const ProfilePageSponsor = ({ profile }) => {
       {profile.benefit_description &&
         <>
           <Divider className={classes.divider} />
-          <Box className={classes.rowBoxLeft}>
+          <Box className={classes.rowBoxInfo}>
             <Typography className={classes.rowTitle} variant="subtitle1">{t('profile.benefitDescription')}</Typography>
             <Typography >{profile.benefit_description}</Typography>
           </Box>


### PR DESCRIPTION
Resolves #634 

### What does this PR do?
Fix that the email has capital letters and fixes the structure of showing the profile fields

### How should this be tested?
- Make run
- Go to Sponsor profile
- Go to Lifebank profile


Before:

<img width="563" alt="Captura de Pantalla 2021-04-05 a la(s) 09 31 32" src="https://user-images.githubusercontent.com/29232417/113591888-b74f0c00-95f1-11eb-82da-13d52f3df2bf.png">

After:

![image](https://user-images.githubusercontent.com/31549144/114940464-1c2f1100-9dff-11eb-8408-7d1704a25907.png)


Before:

![image](https://user-images.githubusercontent.com/31549144/114937840-9198e280-9dfb-11eb-931b-4246db569350.png)


After:

![image](https://user-images.githubusercontent.com/31549144/114940596-4ed90980-9dff-11eb-950e-15c7613dcc6e.png)
