### PR TITLE
Fix/sponsor profile update

### DIFF
--- a/webapp/src/components/MapEditLocation/index.js
+++ b/webapp/src/components/MapEditLocation/index.js
@@ -8,6 +8,7 @@ import Box from '@material-ui/core/Box'
 import { mapboxConfig, constants } from '../../config'
 import MapMarker from '../MapMarker'
 
+const CR_SJ_POINT = { longitude: -84.0556371, latitude: 9.9195872 }
 const initialZoom = 12.5
 const {
   LOCATION_TYPES: { SPONSOR, LIFE_BANK }
@@ -21,6 +22,8 @@ function MapEditLocation({
 }) {
   const mapContainerRef = useRef(null)
   const currentMarker = useRef(null)
+
+  if(!markerLocation) markerLocation = CR_SJ_POINT
 
   let markerNode = null
   let marker = null

--- a/webapp/src/components/MapEditLocation/index.js
+++ b/webapp/src/components/MapEditLocation/index.js
@@ -11,7 +11,7 @@ import MapMarker from '../MapMarker'
 const CR_SJ_POINT = { longitude: -84.0556371, latitude: 9.9195872 }
 const initialZoom = 12.5
 const {
-  LOCATION_TYPES: { SPONSOR, LIFE_BANK }
+  LOCATION_TYPES: { SPONSOR, PENDING_SPONSOR, LIFE_BANK }
 } = constants
 
 function MapEditLocation({
@@ -42,10 +42,13 @@ function MapEditLocation({
     ReactDOM.render(<MapMarker type={markerType} />, markerNode)
 
     marker = new mapboxgl.Marker(markerNode)
-    marker
-      .setLngLat([markerLocation.longitude, markerLocation.latitude])
-      .addTo(map)
-    currentMarker.current = marker
+    
+    if(markerLocation !== CR_SJ_POINT) {
+      marker
+        .setLngLat([markerLocation.longitude, markerLocation.latitude])
+        .addTo(map)
+      currentMarker.current = marker
+    }
 
     map.addControl(
       new MapboxGeocoder({
@@ -89,7 +92,7 @@ function MapEditLocation({
 MapEditLocation.propTypes = {
   onGeolocationChange: PropTypes.func,
   markerLocation: PropTypes.object,
-  markerType: PropTypes.oneOf([SPONSOR, LIFE_BANK]),
+  markerType: PropTypes.oneOf([SPONSOR, PENDING_SPONSOR, LIFE_BANK]),
   props: PropTypes.object
 }
 

--- a/webapp/src/components/MapMarker/index.js
+++ b/webapp/src/components/MapMarker/index.js
@@ -5,6 +5,7 @@ import { makeStyles } from '@material-ui/styles'
 
 import { constants } from '../../config'
 import sponsorSvg from './locator-sponsor-01.svg'
+import pendingSponsorSvg from './locator-donators-01.svg'
 import lifeBankSvg from './locator-donators-01.svg'
 
 const {
@@ -19,7 +20,7 @@ const useStyles = makeStyles((theme) => ({
           return `url(${sponsorSvg})`
 
         case PENDING_SPONSOR:
-          return `url(${lifeBankSvg})`
+          return `url(${pendingSponsorSvg})`
 
         case LIFE_BANK:
           return `url(${lifeBankSvg})`

--- a/webapp/src/components/MapMarker/index.js
+++ b/webapp/src/components/MapMarker/index.js
@@ -8,7 +8,7 @@ import sponsorSvg from './locator-sponsor-01.svg'
 import lifeBankSvg from './locator-donators-01.svg'
 
 const {
-  LOCATION_TYPES: { SPONSOR, LIFE_BANK }
+  LOCATION_TYPES: { PENDING_SPONSOR, SPONSOR, LIFE_BANK }
 } = constants
 
 const useStyles = makeStyles((theme) => ({
@@ -17,6 +17,9 @@ const useStyles = makeStyles((theme) => ({
       switch (type) {
         case SPONSOR:
           return `url(${sponsorSvg})`
+
+        case PENDING_SPONSOR:
+          return `url(${lifeBankSvg})`
 
         case LIFE_BANK:
           return `url(${lifeBankSvg})`
@@ -40,7 +43,7 @@ function MapMarker({ type }) {
 }
 
 MapMarker.propTypes = {
-  type: PropTypes.oneOf([SPONSOR, LIFE_BANK])
+  type: PropTypes.oneOf([SPONSOR, PENDING_SPONSOR, LIFE_BANK])
 }
 
 export default MapMarker

--- a/webapp/src/components/MapPopup/index.js
+++ b/webapp/src/components/MapPopup/index.js
@@ -160,15 +160,17 @@ const MapPopup = ({ id, info, username }) => {
         default:
           dd = 'Saturday'
       }
-
-      JSON.parse(info.schedule).forEach((element) => {
-        if (dd === element.day)
-          if (
-            hour >= parseInt(element.open, 10) &&
-            hour < parseInt(element.close, 10)
-          )
-            setOpen(true)
-      })
+      
+      if(info.schedule) {
+        JSON.parse(info.schedule).forEach((element) => {
+          if (dd === element.day)
+            if (
+              hour >= parseInt(element.open, 10) &&
+              hour < parseInt(element.close, 10)
+            )
+              setOpen(true)
+        })
+      }
     }
   }, [dd, hour])
 

--- a/webapp/src/components/MapShowOneLocation/index.js
+++ b/webapp/src/components/MapShowOneLocation/index.js
@@ -36,7 +36,7 @@ function MapShowOneLocation({ markerLocation, accountProp, ...props }) {
         coordinates: [lng, lat]
       }
     })
-
+    
     data &&
       data.locations &&
       data.locations.forEach((location) => {
@@ -60,7 +60,6 @@ function MapShowOneLocation({ markerLocation, accountProp, ...props }) {
             id={id}
             info={info}
             username={user.username.replaceAll(' ', '-')}
-            account={account}
           />,
           popupNode
         )

--- a/webapp/src/components/MapShowOneLocation/index.js
+++ b/webapp/src/components/MapShowOneLocation/index.js
@@ -36,7 +36,7 @@ function MapShowOneLocation({ markerLocation, accountProp, ...props }) {
         coordinates: [lng, lat]
       }
     })
-    
+
     data &&
       data.locations &&
       data.locations.forEach((location) => {

--- a/webapp/src/config/constants.js
+++ b/webapp/src/config/constants.js
@@ -1,6 +1,7 @@
 export const constants = {
   LOCATION_TYPES: {
     SPONSOR: 'SPONSOR',
+    PENDING_SPONSOR: 'PENDING_SPONSOR',
     LIFE_BANK: 'LIFE_BANK'
   },
   SPONSOR_TYPES: [

--- a/webapp/src/routes/EditProfile/EditProfile.js
+++ b/webapp/src/routes/EditProfile/EditProfile.js
@@ -70,24 +70,21 @@ const EditProfilePage = () => {
     profile?.consent ? revokeConsent() : grantConsent()
   }
 
-  const handleUpdateUser = useCallback(
-    (userEdited, userNameEdited, account) => {
-      editProfile({
+  const handleUpdateUser = (userEdited, userNameEdited, account) => {
+    editProfile({
+      variables: {
+        profile: userEdited
+      }
+    })
+    if (account && userNameEdited) {
+      setUsername({
         variables: {
-          profile: userEdited
+          account: account,
+          username: userNameEdited
         }
       })
-      if (account && userNameEdited) {
-        setUsername({
-          variables: {
-            account: account,
-            username: userNameEdited
-          }
-        })
-      }
-    },
-    [editProfile]
-  )
+    }
+  }
 
   useEffect(() => {
     if (!currentUser) {
@@ -109,7 +106,6 @@ const EditProfilePage = () => {
     const { success } = editProfileResult
 
     if (success) {
-      loadProfile()
       history.push({
         pathname: '/profile',
         state: true
@@ -118,7 +114,7 @@ const EditProfilePage = () => {
     } else if (!success) {
       setShowAlert(true)
     }
-  }, [editProfileResult, loadProfile])
+  }, [editProfileResult])
 
   useEffect(() => {
     if (location.state) {

--- a/webapp/src/routes/EditProfile/EditProfileSponsor.js
+++ b/webapp/src/routes/EditProfile/EditProfileSponsor.js
@@ -519,11 +519,7 @@ const EditProfileSponsor = ({ profile, isCompleting, onSubmit, loading }) => {
             <MapEditLocation
               onGeolocationChange={handleOnGeolocationChange}
               markerType={SPONSOR}
-              markerLocation={
-                user.geolocation
-                  ? user.geolocation
-                  : { longitude: -84.0556371, latitude: 9.9195872 }
-              }
+              markerLocation={user.geolocation}
               width="100%"
               height={400}
               mb={1}

--- a/webapp/src/routes/EditProfile/EditProfileSponsor.js
+++ b/webapp/src/routes/EditProfile/EditProfileSponsor.js
@@ -32,7 +32,7 @@ import styles from './styles'
 const useStyles = makeStyles(styles)
 
 const {
-  LOCATION_TYPES: { SPONSOR },
+  LOCATION_TYPES: { SPONSOR, PENDING_SPONSOR },
   SPONSOR_TYPES
 } = constants
 
@@ -518,7 +518,7 @@ const EditProfileSponsor = ({ profile, isCompleting, onSubmit, loading }) => {
             <Typography className={classes.boldText} variant="subtitle1">{t('miscellaneous.location')}</Typography>
             <MapEditLocation
               onGeolocationChange={handleOnGeolocationChange}
-              markerType={SPONSOR}
+              markerType={user.geolocation ? SPONSOR : PENDING_SPONSOR}
               markerLocation={user.geolocation}
               width="100%"
               height={400}


### PR DESCRIPTION
Resolves #640 

### What does this PR do?
Remove unnecessary loadProfile query and allow a better understanding when the user is editing its profile in the location section, now the user is able to notice when has clicked a sponsor location and when not

### How should this be tested?
- Make run
- Go to profile
- Go to edit profile
- Scroll down to location section
- Notice when a location is clicked and when not
