### PR TITLE
fix(backend): add exist field to return query

### DIFF
--- a/hapi/src/api/email.api.js
+++ b/hapi/src/api/email.api.js
@@ -63,16 +63,17 @@ const checkEmailVerified = async ({ account }) => {
     ]
   })
 
-  if (user) return { verified: user.email_verified }
+  if (user) return { exist: true, verified: user.email_verified }
 
   const preRegisterUser = await preRegisterLifebankApi.getOne({
     email: { _eq: account }
   })
 
   if (preRegisterUser.preregister_lifebank.length > 0)
-    return { verified: preRegisterUser.preregister_lifebank[0].email_verified }
+    return { exist: true, verified: preRegisterUser.preregister_lifebank[0].email_verified }
 
   return {
+    exist: false,
     verified: false
   }
 }

--- a/hapi/src/api/email.api.js
+++ b/hapi/src/api/email.api.js
@@ -70,7 +70,10 @@ const checkEmailVerified = async ({ account }) => {
   })
 
   if (preRegisterUser.preregister_lifebank.length > 0)
-    return { exist: true, verified: preRegisterUser.preregister_lifebank[0].email_verified }
+    return {
+      exist: true,
+      verified: preRegisterUser.preregister_lifebank[0].email_verified
+    }
 
   return {
     exist: false,

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -328,6 +328,7 @@ type get_report_output {
 }
 
 type check_email_verified_output {
+  exist : Boolean!
   verified : Boolean!
 }
 

--- a/webapp/src/components/LoginModal/Login.js
+++ b/webapp/src/components/LoginModal/Login.js
@@ -189,7 +189,7 @@ const LoginModal = ({ isNavBar, isSideBar }) => {
   }, [loginResult])
 
   useEffect(() => {
-    if (checkEmailVerifiedResult && !checkEmailVerifiedResult.verified) {
+    if (checkEmailVerifiedResult && checkEmailVerifiedResult.exist && !checkEmailVerifiedResult.verified) {
       verify()
     }
   }, [checkEmailVerifiedResult])

--- a/webapp/src/gql/account.gql.js
+++ b/webapp/src/gql/account.gql.js
@@ -72,6 +72,7 @@ export const SEND_EMAIL_MUTATION = gql`
 export const CHECK_EMAIL_VERIFIED = gql`
   mutation($account: String!) {
     check_email_verified(account: $account) {
+      exist
       verified
     }
   }


### PR DESCRIPTION
Resolves #736 

### What does this PR do?
Show resend email option only for existing user with no verified email

### How should this be tested?
- Make run
- Try to login with no existing account (email, username or account)
- Check that resend modal don't show up
