### PR TITLE
fix(frontend): move mapbox below in desktop version

### DIFF
--- a/webapp/src/language/en.json
+++ b/webapp/src/language/en.json
@@ -304,6 +304,8 @@
       "contactInformation": "Contact Information",
       "addressInformation": "Address Information",
       "addressDescription": "Describe your address and use the map to select the right location so the donors can get to you easily.",
+      "mapInformation": "Choose your location",
+      "mapDescription": "Please select the right location so the donors can get to you easily.",
       "imagery": "Images",
       "imageryDescription": "Include images that are appealing to donors! Paste a link to an image you want to include in your profile. You can upload images using imgur.com for free. Your logo or avatar must be square-shaped and no larger than 500 px or bigger than 250 KB. The banner image should be horizontal, no larger than 1200 px wide or bigger than 1 MB",
       "city": "City",

--- a/webapp/src/language/es.json
+++ b/webapp/src/language/es.json
@@ -310,7 +310,7 @@
       "contactInformation": "Información de Contacto",
       "addressInformation": "Datos de Domicilio",
       "addressDescription": "Describe tu dirección de Lifebank y usa el mapa para seleccionar la ubicación correcta para que los donantes puedan llegar a ti fácilmente.",
-      "mapInformation": "Datos de Geolocalización",
+      "mapInformation": "Escoge tu ubicación",
       "mapDescription": "Porfavor selecciona la ubicación correcta para que los donantes puedan llegar a ti fácilmente.",
       "imagery": "Imágenes",
       "imageryDescription": "Escribe un enlace a tus imágenes para que tu página de Lifebank se muestre más atractiva para tus donantes. Puedes subir imágenes al logotipo de IMGUR.com o la imagen de avatar debe ser una imagen cuadrada, no mayor de 500px o más pesada de 250kb. La imagen del banner debe ser una imagen horizontal, no mayor a 1200px ni más pesada que 1mb.",

--- a/webapp/src/language/es.json
+++ b/webapp/src/language/es.json
@@ -310,6 +310,8 @@
       "contactInformation": "Información de Contacto",
       "addressInformation": "Datos de Domicilio",
       "addressDescription": "Describe tu dirección de Lifebank y usa el mapa para seleccionar la ubicación correcta para que los donantes puedan llegar a ti fácilmente.",
+      "mapInformation": "Datos de Geolocalización",
+      "mapDescription": "Porfavor selecciona la ubicación correcta para que los donantes puedan llegar a ti fácilmente.",
       "imagery": "Imágenes",
       "imageryDescription": "Escribe un enlace a tus imágenes para que tu página de Lifebank se muestre más atractiva para tus donantes. Puedes subir imágenes al logotipo de IMGUR.com o la imagen de avatar debe ser una imagen cuadrada, no mayor de 500px o más pesada de 250kb. La imagen del banner debe ser una imagen horizontal, no mayor a 1200px ni más pesada que 1mb.",
       "city": "Ciudad",

--- a/webapp/src/routes/EditProfile/EditProfileBank.js
+++ b/webapp/src/routes/EditProfile/EditProfileBank.js
@@ -337,7 +337,7 @@ const EditProfileBank = ({ profile, onSubmit, setField, loading, userName }) => 
               {t('editProfile.addressDescription')}
             </Typography>
           </Grid>
-          <Grid container item xs={6} spacing={SPACING}>
+          <Grid container item xs={12} spacing={SPACING}>
             <Grid item xs={12}>
               <TextField
                 className={classes.textField}
@@ -429,16 +429,24 @@ const EditProfileBank = ({ profile, onSubmit, setField, loading, userName }) => 
               />
             </Grid>
           </Grid>
-          <Grid item xs={6}>
-            <Box width="100%">
-              <MapEditLocation
-                onGeolocationChange={handleOnGeolocationChange}
-                markerLocation={user.geolocation}
-                markerType={LIFE_BANK}
-                className={classes.mapField}
-                mb={1}
-              />
-            </Box>
+        </Grid>
+        <Grid container item xs={12} spacing={SPACING}>
+          <Grid item xs={12}>
+            <Typography className={classes.boldText} variant="h4">
+              {t('editProfile.mapInformation')}
+            </Typography>
+            <Typography className={classes.text} variant="body1">
+              {t('editProfile.mapDescription')}
+            </Typography>
+          </Grid>
+          <Grid item xs={12}>
+            <MapEditLocation
+              onGeolocationChange={handleOnGeolocationChange}
+              markerLocation={user.geolocation}
+              markerType={LIFE_BANK}
+              className={classes.mapField}
+              mb={1}
+            />
           </Grid>
         </Grid>
         <Grid container item xs={12} spacing={SPACING}>

--- a/webapp/src/routes/EditProfile/EditProfileSponsor.js
+++ b/webapp/src/routes/EditProfile/EditProfileSponsor.js
@@ -336,7 +336,7 @@ const EditProfileSponsor = ({ profile, onSubmit, loading }) => {
               {t('editProfile.addressDescription')}
             </Typography>
           </Grid>
-          <Grid container item xs={6}>
+          <Grid container item xs={12}>
             <Grid item xs={12}>
               <TextField
                 id="address"
@@ -428,16 +428,24 @@ const EditProfileSponsor = ({ profile, onSubmit, loading }) => {
               />
             </Grid>
           </Grid>
-          <Grid container item xs={6}>
-            <>
-              <MapEditLocation
-                onGeolocationChange={handleOnGeolocationChange}
-                markerType={user.geolocation ? SPONSOR : PENDING_SPONSOR}
-                markerLocation={user.geolocation}
-                className={classes.mapField}
-                mb={1}
-              />
-            </>
+        </Grid>
+        <Grid container item xs={12} spacing={SPACING}>
+          <Grid item xs={12}>
+            <Typography className={classes.boldText} variant="h4">
+              {t('editProfile.mapInformation')}
+            </Typography>
+            <Typography className={classes.text} variant="body1">
+              {t('editProfile.mapDescription')}
+            </Typography>
+          </Grid>
+          <Grid item xs={12}>
+            <MapEditLocation
+              onGeolocationChange={handleOnGeolocationChange}
+              markerType={user.geolocation ? SPONSOR : PENDING_SPONSOR}
+              markerLocation={user.geolocation}
+              className={classes.mapField}
+              mb={1}
+            />
           </Grid>
         </Grid>
         <Grid container item xs={12} spacing={SPACING}>


### PR DESCRIPTION
Resolves #823 

### What does this PR do?
Move mapbox below in desktop version

### How should this be tested?
- Make run
- Go to edit profile under Lifebank or Sponsor session
- Check mapbox in desktop version is below of address section


New view:
![image](https://user-images.githubusercontent.com/28828796/122585586-e41f9680-d018-11eb-8f25-81d8ae586133.png)
